### PR TITLE
lock this in on 2020-04-29

### DIFF
--- a/2_observations.yml
+++ b/2_observations.yml
@@ -26,7 +26,7 @@ targets:
   tmp/filtered_observations.rds:
     command: filter_feather_obs(target_name, site_ids = modeled_lake_ids,
       obs_start = export_start, obs_stop = export_stop,
-      obs_feather = '../lake-temperature-model-prep/7b_temp_merge/out/temp_data_with_sources.feather')
+      obs_feather = I('../lake-temperature-model-prep/7b_temp_merge/out/temp_data_with_sources.feather'))
 
   out_data/temperature_observations.zip:
     command: zip_filter_obs(target_name, 'tmp/filtered_observations.rds')

--- a/in_text/text_01_spatial.yml
+++ b/in_text/text_01_spatial.yml
@@ -59,14 +59,14 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: centroid_lon centroid_lat" "state"        "county"       "lake_name"
+      attr-label: centroid_lon centroid_lat
       attr-def: longitude (decimal-degrees) of the centroid of this lake (for purposes of calculating group_id and linking meteorological data cells)
       attr-defs: NA
       data-min: -99.42552
       data-max: -83.08698
       data-units: decimal-degrees
     -
-      attr-label: centroid_lat" "state"        "county"       "lake_name"
+      attr-label: centroid_lat
       attr-def: latitude (decimal-degrees) of the centroid of this lake (for purposes of calculating group_id and linking meteorological data cells)
       attr-defs: NA
       data-min: 40.9117
@@ -82,7 +82,7 @@ entities:
       data-max: NA
       data-units: NA
     -
-      attr-label: county"       "lake_name"
+      attr-label: county
       attr-def: >-
         County name for each county overlapped by this lake.
         When more than one county, county names are separated by "|", such as "Lake|St. Louis"

--- a/in_text/text_03_config.yml
+++ b/in_text/text_03_config.yml
@@ -182,6 +182,6 @@ latitude-res: 0.1
 longitude-res: 0.1
 data-name: Model configuration details
 data-description: >-
-  Model configurations for running the General Lake Model (Hipsey et al. 2019) version 2 for each lake.
+  Model configurations for running the General Lake Model (Hipsey et al. 2019) version 3 for each lake.
   The value for "lake_name" in the "morphometry" field is the mapping for "site_id" for the other datasets included in this release.
 file-format: JSON (JavaScript Object Notation) formatted text file

--- a/src/file_utils.R
+++ b/src/file_utils.R
@@ -1,6 +1,6 @@
 
 split_pb_filenames <- function(files_df){
-  extract(files_df, file, c('prefix','site_id','suffix'), "(pb0|pball)_(.*)_(temperatures_irradiance.feather)", remove = FALSE)
+  extract(files_df, file, c('prefix','site_id','suffix'), "(pb0|pball)_(.*)_(temperatures_irradiance.feather|temperatures.feather)", remove = FALSE)
 }
 
 extract_pb0_ids <- function(model_out_ind){
@@ -274,7 +274,7 @@ zip_pb_export_groups <- function(outfile, file_info_df, site_groups,
 
       model_data <- feather::read_feather(these_files$source_filepath[i]) %>%
         rename(kd = extc_coef_0) %>%
-        mutate(date = as.Date(lubridate::ceiling_date(time, 'days'))) %>%
+        mutate(date = as.Date(lubridate::floor_date(time, 'days'))) %>%
         filter(date >= export_start & date <= export_stop)
 
       switch(export,


### PR DESCRIPTION
We want to move forward on the `prep` pipeline, but we don't want this release to be a moving target.