### PR TITLE
simple file.copy for moving non-hash yml files

### DIFF
--- a/7_habitat.yml
+++ b/7_habitat.yml
@@ -24,7 +24,9 @@ targets:
       add_path = I('../lake-temperature-out'))
 
   out_data/7_pb0_annual_metrics.csv:
-    command: file.copy('../lake-temperature-out/3_summarize/out/annual_metrics_pb0.csv', target_name)
+    command: file.copy(to = target_name,
+      from = '../lake-temperature-out/3_summarize/out/annual_metrics_pb0.csv',
+      overwrite = TRUE)
 
   out/7_pgdl_toha_zips.yml:
     command: update_hash_path(target_name,
@@ -32,7 +34,9 @@ targets:
       add_path = I('../lake-temperature-out'))
 
   out_data/7_pgdl_annual_metrics.csv:
-    command: file.copy('../lake-temperature-out/3_summarize/out/annual_metrics_pgdl.csv', target_name)
+    command: file.copy(to = target_name,
+      from = '../lake-temperature-out/3_summarize/out/annual_metrics_pgdl.csv',
+      overwrite = TRUE)
 
   # Step to partially automate the manual process of adding metadata for each temp range
   # variable. Once you build this file, manually copy the contents and place in the

--- a/7_habitat.yml
+++ b/7_habitat.yml
@@ -24,9 +24,7 @@ targets:
       add_path = I('../lake-temperature-out'))
 
   out_data/7_pb0_annual_metrics.csv:
-    command: update_hash_path(target_name,
-      '../lake-temperature-out/3_summarize/out/annual_metrics_pb0.csv',
-      add_path = I('../lake-temperature-out'))
+    command: file.copy('../lake-temperature-out/3_summarize/out/annual_metrics_pb0.csv', target_name)
 
   out/7_pgdl_toha_zips.yml:
     command: update_hash_path(target_name,
@@ -34,9 +32,7 @@ targets:
       add_path = I('../lake-temperature-out'))
 
   out_data/7_pgdl_annual_metrics.csv:
-    command: update_hash_path(target_name,
-      '../lake-temperature-out/3_summarize/out/annual_metrics_pgdl.csv',
-      add_path = I('../lake-temperature-out'))
+    command: file.copy('../lake-temperature-out/3_summarize/out/annual_metrics_pgdl.csv', target_name)
 
   # Step to partially automate the manual process of adding metadata for each temp range
   # variable. Once you build this file, manually copy the contents and place in the


### PR DESCRIPTION
Updated `7_habitat.yml` based on a [realization in the hyperscales-data-release repo](https://github.com/jread-usgs/hyperscales-data-release/pull/21#discussion_r574830927), where non-hash yml files do not need fancy handler fxns to get moved from one repo to another. They can just be copied over.