### PR TITLE
Metadata touch ups

### DIFF
--- a/in_text/text_01_spatial.yml
+++ b/in_text/text_01_spatial.yml
@@ -111,7 +111,10 @@ entities:
       data-units: unitless
     -
       attr-label: total_benthic_area
-      attr-def: LINDSAY HELP FILL THIS OUT!!!!!
+      attr-def: >-
+        Using the available hypsography for each lake, a benthic area (area of lake bottom) was estimated by assuming the lake
+        cross section resembled a trapezoid. Using each known depth-area relationship, the sides of the trapezoid were calculated
+        and then summed along with the deepest known area (to capture the actual lake bottom) to get a total benthic area.
       attr-defs: NA
       data-min: NA
       data-max: NA
@@ -148,6 +151,7 @@ entities:
 data-name: Polygons for study lakes
 data-description: Shapefile of study lakes included in this data release; metadata file for lakes in this data release
 
+process-date: !expr format(Sys.time(),'%Y%m%d')
 file-format: Shapefile Data Set
 
 build-environment: >-

--- a/in_text/text_02_observations.yml
+++ b/in_text/text_02_observations.yml
@@ -23,8 +23,8 @@ cross-cites:
 
 entities:
   -
-    data-name: 03_temperature_observations.csv
-    data-description: Temperature observation data for 877 lakes
+    data-name: temperature_observations.zip
+    data-description: A zip file containing one csv of all temperature observation data for 877 lakes
     attributes:
     -
       attr-label: site_id

--- a/in_text/text_02_observations.yml
+++ b/in_text/text_02_observations.yml
@@ -64,4 +64,5 @@ entities:
       data-max: NA
       data-units: NA
 
+process-date: !expr format(Sys.time(),'%Y%m%d')
 file-format: a single comma-delimited file

--- a/in_text/text_04_inputs.yml
+++ b/in_text/text_04_inputs.yml
@@ -18,7 +18,120 @@ cross-cites:
     pubdate: 2019
     link: https://doi.org/10.5194/gmd-12-473-2019
 
-
+entities:
+  -
+    data-name: clarity_{group_id}_N{minN-maxN}_W{minW-maxW}.zip
+    data-description: >-
+      A zip file containing a csv file for every lake within {group_id} with clarity data. Files within the
+      zip are named "gam_{site_id}_clarity.csv", where `site_id` is the lake nhdhr id.
+    attributes:
+      -
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: kd
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+  -
+    data-name: ice_flags_{group_id}_N{minN-maxN}_W{minW-maxW}.zip
+    data-description: >-
+      A zip file containing a csv file for every lake within {group_id} with ice cover data. Files within the
+      zip are named "pb0_{site_id}_ice_flags.csv", where `site_id` is the lake nhdhr id.
+    attributes:
+      -
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: ice
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+  -
+    data-name: inputs_{group_id}_N{minN-maxN}_W{minW-maxW}.zip
+    data-description: >-
+      A zip file containing a csv file for every lake within {group_id} with input data. Files within the
+      zip are named "nldas_meteo_N{minN-maxN}_W{minW-maxW}.csv", where ???? these min/max are different from group ????.
+    attributes:
+      -
+        attr-label: time
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: ShortWave
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: LongWave
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: AirTemp
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: RelHum
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: WindSpeed
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: Rain
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: Snow
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+  -
+    data-name: input_cells.png
+    data-description: A PNG file ... see example https://github.com/USGS-R/pgmtl-data-release/blob/master/in_text/text_05_predictions.yml#L47
+    attributes:
+      -
+        attr-label: PNG image
+        attr-def: NA
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: NA
 
 build-environment: Multiple computer systems were used to generate these data, including linux, OSX. The open source language R was used on all systems, as well as the open-source model GLM.
 

--- a/in_text/text_05_predictions.yml
+++ b/in_text/text_05_predictions.yml
@@ -40,9 +40,81 @@ cross-cites:
     pubdate: 2019
     link: https://doi.org/10.5066/F7D798MJ
 
+entities:
+  -
+    data-name: irradiance_{group_id}_N{minN-maxN}_W{minW-maxW}.zip
+    data-description: >-
+      A zip file containing a csv file for every lake within {group_id} with irradiance data. Files within the
+      zip are named "pb0_{site_id}_irradiance.csv", where `site_id` is the lake nhdhr id.
+    attributes:
+      -
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: rad_0
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+  -
+    data-name: pb0_predictions_{group_id}_N{minN-maxN}_W{minW-maxW}.zip
+    data-description: >-
+      A zip file containing a csv file for every lake within {group_id} with uncalibrated model output temperature data. Files within the
+      zip are named "pb0_{site_id}_temperatures.csv", where `site_id` is the lake nhdhr id.
+    attributes:
+      -
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: temp_{depth}
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+  -
+    data-name: pgdl_predictions_{group_id}_N{minN-maxN}_W{minW-maxW}.zip
+    data-description: >-
+      A zip file containing a csv file for every lake within {group_id} with Process-Guided Deep Learning model output
+      temperature data. Files within the zip are named "pgdl_{site_id}_temperatures.csv", where `site_id` is the lake nhdhr id.
+    attributes:
+      -
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: temp_{depth}
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+  -
+    data-name: predict_lakes.png
+    data-description: A PNG file ... see example https://github.com/USGS-R/pgmtl-data-release/blob/master/in_text/text_05_predictions.yml#L47
+    attributes:
+      -
+        attr-label: PNG image
+        attr-def: NA
+        attr-defs: This data release
+        data-min: NA
+        data-max: NA
+        data-units: NA
+
 build-environment: >-
   For PB and PB0 predictions we used USGS Advanced Research Computing, USGS Yeti Supercomputer (https://doi.org/10.5066/F7D798MJ); process-based predictions were generated with the following open source tools available in the R programming language (R version 3.5.0 (2018-04-23)).\n
   The computing platform for generating data and metadata was x86_64-redhat-linux-gnu. R packages loaded into this environment: dplyr, version: 0.8.1; glmtools, version: 0.15.0; rLakeAnalyzer, version: 1.11.4; GLMr, version: 3.1.14; readr, version: 1.3.1;
   Yeti modules tools/nco-4.7.8-gnu; tools/netcdf-4.3.2-gnu
   For PGDL predictions, the {{{{{ FILL IN HERE }}}}}
-

--- a/in_text/text_05_predictions.yml
+++ b/in_text/text_05_predictions.yml
@@ -118,3 +118,7 @@ build-environment: >-
   The computing platform for generating data and metadata was x86_64-redhat-linux-gnu. R packages loaded into this environment: dplyr, version: 0.8.1; glmtools, version: 0.15.0; rLakeAnalyzer, version: 1.11.4; GLMr, version: 3.1.14; readr, version: 1.3.1;
   Yeti modules tools/nco-4.7.8-gnu; tools/netcdf-4.3.2-gnu
   For PGDL predictions, the {{{{{ FILL IN HERE }}}}}
+
+process-date: !expr format(Sys.time(),'%Y%m%d')
+file-format: >-
+  39 compressed zip files and one PNG file

--- a/in_text/text_06_evaluation.yml
+++ b/in_text/text_06_evaluation.yml
@@ -1,6 +1,12 @@
 title: >-
   Walleye Thermal Optical Habitat Area (TOHA) of selected Minnesota lakes: 6 model evaluation
 
+abstract: >-
+  NEED TO FILL THIS IN
+
+build-environment: >-
+  NEED TO FILL THIS IN
+
 entities:
   -
     data-name: pb0_evaluation.csv
@@ -131,3 +137,7 @@ entities:
         data-min: [COLUMN MIN if applicable, NA if not]
         data-max: [COLUMN MAX if applicable, NA if not]
         data-units: [COLUMN UNITS if applicable, NA if not]
+
+process-date: !expr format(Sys.time(),'%Y%m%d')
+file-format: >-
+  two compressed zip files and two csv files

--- a/in_text/text_06_evaluation.yml
+++ b/in_text/text_06_evaluation.yml
@@ -29,14 +29,35 @@ entities:
     data-description: FILLLLL INN THISSSSS
     attributes:
       -
-        attr-label: [COLUMN NAME]
+        attr-label: site_id
         attr-def: [COLUMN DESCRIPTION]
         attr-defs: [SOURCE, saying "This data release" is OK]
         data-min: [COLUMN MIN if applicable, NA if not]
         data-max: [COLUMN MAX if applicable, NA if not]
         data-units: [COLUMN UNITS if applicable, NA if not]
       -
-        attr-label: [COLUMN NAME]
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: depth
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: obs
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: pred
         attr-def: [COLUMN DESCRIPTION]
         attr-defs: [SOURCE, saying "This data release" is OK]
         data-min: [COLUMN MIN if applicable, NA if not]
@@ -47,32 +68,64 @@ entities:
     data-description: FILLLLL INN THISSSSS
     attributes:
       -
-        attr-label: [COLUMN NAME]
-        attr-def: [COLUMN DESCRIPTION]
-        attr-defs: [SOURCE, saying "This data release" is OK]
-        data-min: [COLUMN MIN if applicable, NA if not]
-        data-max: [COLUMN MAX if applicable, NA if not]
-        data-units: [COLUMN UNITS if applicable, NA if not]
+        attr-label: site_id
+        attr-def: >-
+          Lake identification number for this dataset. Is the Prmnn_I prefixed with source, as "nhd_{Prmnn_I}". The "target" lake being predicted
+        attr-defs: >-
+          http://nhd.usgs.gov/
+        data-min: NA
+        data-max: NA
+        data-units: NA
       -
-        attr-label: [COLUMN NAME]
-        attr-def: [COLUMN DESCRIPTION]
-        attr-defs: [SOURCE, saying "This data release" is OK]
-        data-min: [COLUMN MIN if applicable, NA if not]
-        data-max: [COLUMN MAX if applicable, NA if not]
-        data-units: [COLUMN UNITS if applicable, NA if not]
+        attr-label: rmse
+        attr-def: >-
+          Root-mean square error (in degrees C) of the process-guided deep learning transfered model predictions.
+        attr-defs: >-
+          https://en.wikipedia.org/wiki/Root-mean-square_deviation
+        data-min: 0.849
+        data-max: 8.052
+        data-units: degrees C
   -
     data-name: pgdl_matched_to_observations.zip
     data-description: FILLLLL INN THISSSSS
     attributes:
       -
-        attr-label: [COLUMN NAME]
+        attr-label: site_id
         attr-def: [COLUMN DESCRIPTION]
         attr-defs: [SOURCE, saying "This data release" is OK]
         data-min: [COLUMN MIN if applicable, NA if not]
         data-max: [COLUMN MAX if applicable, NA if not]
         data-units: [COLUMN UNITS if applicable, NA if not]
       -
-        attr-label: [COLUMN NAME]
+        attr-label: date
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: depth
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: obs
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: source_id
+        attr-def: [COLUMN DESCRIPTION]
+        attr-defs: [SOURCE, saying "This data release" is OK]
+        data-min: [COLUMN MIN if applicable, NA if not]
+        data-max: [COLUMN MAX if applicable, NA if not]
+        data-units: [COLUMN UNITS if applicable, NA if not]
+      -
+        attr-label: pred
         attr-def: [COLUMN DESCRIPTION]
         attr-defs: [SOURCE, saying "This data release" is OK]
         data-min: [COLUMN MIN if applicable, NA if not]

--- a/in_text/text_07_habitat.yml
+++ b/in_text/text_07_habitat.yml
@@ -164,7 +164,7 @@ entities:
         data-max: NA
         data-units: m^2
   -
-    data-name: annual_metrics_{model}.csv
+    data-name: 7_{model}_annual_metrics.csv
     data-description: >-
       A csv file containing annual summaries of thermal metrics based on modeled temperatures. {model} is either "pb0"
       for the uncalibrated Process-Based model outputs or "pgdl" for the Process-Guided Deep Learning model outputs.

--- a/in_text/text_SHARED.yml
+++ b/in_text/text_SHARED.yml
@@ -14,7 +14,7 @@ larger-cites:
     pubdate: 2019
 
 purpose: Fisheries biology, limnological research, and climate science.
-start-date: 19800401
+start-date: 19791201
 end-date: 20181231
 
 update: none planned


### PR DESCRIPTION
After running checks in #33, these changes make it so that all files and file attributes have a spot in the ymls. Details still need to be filled in based on #34, #35, and #36.  In addition, I did a full scan through all of the ymls and made additional changes: update dates for the full data release, fill in process dates & file formats, include total benthic area definition, and add a few placeholders for 06_evaluation.