### PR TITLE
remove source_id column from matched pgdl preds

### DIFF
--- a/log/06_evaluationPGDL_sb.csv
+++ b/log/06_evaluationPGDL_sb.csv
@@ -1,0 +1,3 @@
+filepath,sb_id,time_uploaded_to_sb
+out_data/pgdl_matched_to_observations.zip,5e774324e4b01d509270e29f,2021-03-02 21:33 UTC
+out_data/pgdl_evaluation.csv,5e774324e4b01d509270e29f,2021-02-23 19:54 UTC

--- a/src/eval_utils.R
+++ b/src/eval_utils.R
@@ -79,7 +79,8 @@ match_preds_to_obs  <- function(out_zip, observations_zip='out_data/temperature_
       unzip(source_zip, overwrite = TRUE)
     }
     these_preds <- read_preds_release(pred_path)
-    prep_pred_obs(these_obs, these_preds)
+    prep_pred_obs(these_obs, these_preds) %>%
+      select(site_id, date, depth, obs, pred)
   })
 
   zip_this(outfile=out_zip, .object=matched_preds)
@@ -88,7 +89,7 @@ match_preds_to_obs  <- function(out_zip, observations_zip='out_data/temperature_
 # Evaluate RMSE of predictions
 evaluate_preds <- function(out_file, matched_preds_zip){
 
-  matched_preds <- unzip_to_tibble(matched_preds_zip, col_types='cDddcd')
+  matched_preds <- unzip_to_tibble(matched_preds_zip, col_types='cDddd')
 
   matched_preds %>%
     group_by(site_id) %>%


### PR DESCRIPTION
* remove `source_id` column from `pgdl_matched_to_observations.csv` within `pgdl_matched_to_observations.zip`
* modify `evaluate_preds()` function to account for reduced # of columns in input dataframe
* push updated `pgdl_matched_to_observations.zip` to science base