### PR TITLE
Config metadata

### DIFF
--- a/log/03_configXML_sb.csv
+++ b/log/03_configXML_sb.csv
@@ -1,0 +1,2 @@
+filepath,sb_id,time_uploaded_to_sb
+out_xml/03_config.xml,5e5c1c36e4b01d50924f27ea,2021-03-08 15:42 UTC

--- a/remake.yml
+++ b/remake.yml
@@ -92,9 +92,13 @@ targets:
   log/03_configPB_sb.csv:
     command: sb_replace_files(target_name,
       sbid_03_config,
-      "out_xml/03_config.xml",
       "out_data/pb0_config.json",
       "out_data/pb0_nml_files.zip")
+      
+  log/03_configXML_sb.csv:
+    command: sb_replace_files(target_name, 
+      sbid_03_config,
+      "out_xml/03_config.xml")
 
   log/03_configPGDL_sb.csv:
     command: sb_replace_files(target_name,


### PR DESCRIPTION
* Put `out_xml/03_config.xml` into separate target in `remake.yml`, b/c the files previously included alongside that file in the call to `sb_replace_files` command -- `out_data/pb0_config.json` and `out_data/pb0_nml_files.zip` -- aren't on tallgrass.
* Track log file with update timestamp - `log/03_configXML_sb.csv`