### PR TITLE
Update definitions & data due to change in ice_on calc

### DIFF
--- a/in_text/text_07_habitat.yml
+++ b/in_text/text_07_habitat.yml
@@ -208,14 +208,21 @@ entities:
         data-units: NA
       -
         attr-label: ice_on_date
-        attr-def: Date of ice-on
+        attr-def: >-
+          Date of ice-on for the current year's winter season. This could mean that the
+          date actually occurs in the previous year (e.g. ice-on for winter of 2017 happened
+          in December of 2016). This definition of ice-on is consistent with the Wisconsin
+          State Climatology Office's use of ice-on and ice-off dates by winter season. If
+          this value is `NA`, it means that no ice formed during that winter season.
         attr-defs: This data release
         data-min: NA
         data-max: NA
         data-units: NA
       -
         attr-label: ice_off_date
-        attr-def: Date of ice-off
+        attr-def: >-
+          Date of ice-off for the current year's winter season. If this
+          value is `NA`, it means that no ice formed during that winter season.
         attr-defs: This data release
         data-min: NA
         data-max: NA
@@ -1278,9 +1285,11 @@ entities:
       -
         attr-label: open_water_duration
         attr-def: >-
-          Number of days between ice-on and ice-off. If `NA`, the open water
-          period could not be calculated because there was not an ice-off or
-          ice-on date for that year.
+          Number of days between ice-off for this year's winter season and ice-on
+          for the next year's winter season. If `NA`, the open water period could
+          not be calculated because there was either not an ice-off date for this
+          year's winter season or an ice-on date for the next year's winter season
+          or both were missing.
         attr-defs: This data release
         data-min: NA
         data-max: NA

--- a/log/03_configXML_sb.csv
+++ b/log/03_configXML_sb.csv
@@ -1,0 +1,2 @@
+filepath,sb_id,time_uploaded_to_sb
+out_xml/03_config.xml,5e5c1c36e4b01d50924f27ea,2021-03-08 15:42 UTC

--- a/log/07_habitatPB_sb.csv
+++ b/log/07_habitatPB_sb.csv
@@ -12,4 +12,4 @@ filepath,sb_id,time_uploaded_to_sb
 ../lake-temperature-out/3_summarize/tmp/pb0_toha_11_N45.00-45.50_W92.25-93.25.zip,5e774355e4b01d509270e2a1,2021-01-11 16:45 UTC
 ../lake-temperature-out/3_summarize/tmp/pb0_toha_12_N43.50-45.00_W93.50-96.75.zip,5e774355e4b01d509270e2a1,2021-01-11 16:45 UTC
 ../lake-temperature-out/3_summarize/tmp/pb0_toha_13_N43.50-45.00_W91.00-93.50.zip,5e774355e4b01d509270e2a1,2021-01-11 16:45 UTC
-out_data/7_pb0_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-03-08 15:32 UTC
+out_data/7_pb0_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-03-30 19:12 UTC

--- a/log/07_habitatPGDL_sb.csv
+++ b/log/07_habitatPGDL_sb.csv
@@ -12,4 +12,4 @@ filepath,sb_id,time_uploaded_to_sb
 ../lake-temperature-out/3_summarize/tmp/pgdl_toha_11_N45.00-45.50_W92.25-93.25.zip,5e774355e4b01d509270e2a1,2021-02-25 19:08 UTC
 ../lake-temperature-out/3_summarize/tmp/pgdl_toha_12_N43.50-45.00_W93.50-96.75.zip,5e774355e4b01d509270e2a1,2021-02-25 19:08 UTC
 ../lake-temperature-out/3_summarize/tmp/pgdl_toha_13_N43.50-45.00_W91.00-93.50.zip,5e774355e4b01d509270e2a1,2021-02-25 19:08 UTC
-out_data/7_pgdl_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-03-08 15:26 UTC
+out_data/7_pgdl_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-03-30 19:18 UTC

--- a/log/07_habitat_xml_sb.csv
+++ b/log/07_habitat_xml_sb.csv
@@ -1,2 +1,2 @@
 filepath,sb_id,time_uploaded_to_sb
-out_xml/07_habitat.xml,5e774355e4b01d509270e2a1,2021-03-04 17:18 UTC
+out_xml/07_habitat.xml,5e774355e4b01d509270e2a1,2021-03-30 19:42 UTC

--- a/remake.yml
+++ b/remake.yml
@@ -92,9 +92,13 @@ targets:
   log/03_configPB_sb.csv:
     command: sb_replace_files(target_name,
       sbid_03_config,
-      "out_xml/03_config.xml",
       "out_data/pb0_config.json",
       "out_data/pb0_nml_files.zip")
+      
+  log/03_configXML_sb.csv:
+    command: sb_replace_files(target_name, 
+      sbid_03_config,
+      "out_xml/03_config.xml")
 
   log/03_configPGDL_sb.csv:
     command: sb_replace_files(target_name,


### PR DESCRIPTION
Update ice_on_date, ice_off_date, and open_water_duration definitions and rebuild data to reflect changes made in https://github.com/USGS-R/lake-temperature-out/pull/55.

~draft for now because I will include the updates to the actual SB files once the builds complete~