### PR TITLE
One more "ice_on_date" fix: NA if no winter data

### DIFF
--- a/in_text/text_07_habitat.yml
+++ b/in_text/text_07_habitat.yml
@@ -213,7 +213,9 @@ entities:
           date actually occurs in the previous year (e.g. ice-on for winter of 2017 happened
           in December of 2016). This definition of ice-on is consistent with the Wisconsin
           State Climatology Office's use of ice-on and ice-off dates by winter season. If
-          this value is `NA`, it means that no ice formed during that winter season.
+          this value is `NA`, it means that no ice formed during that winter season or that 
+          there was not ice data available for the full winter season (e.g. for the first
+          year of the timeseries).
         attr-defs: This data release
         data-min: NA
         data-max: NA

--- a/log/07_habitatPB_sb.csv
+++ b/log/07_habitatPB_sb.csv
@@ -12,4 +12,4 @@ filepath,sb_id,time_uploaded_to_sb
 ../lake-temperature-out/3_summarize/tmp/pb0_toha_11_N45.00-45.50_W92.25-93.25.zip,5e774355e4b01d509270e2a1,2021-04-16 14:05 UTC
 ../lake-temperature-out/3_summarize/tmp/pb0_toha_12_N43.50-45.00_W93.50-96.75.zip,5e774355e4b01d509270e2a1,2021-04-16 14:05 UTC
 ../lake-temperature-out/3_summarize/tmp/pb0_toha_13_N43.50-45.00_W91.00-93.50.zip,5e774355e4b01d509270e2a1,2021-04-16 14:05 UTC
-out_data/7_pb0_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-04-16 14:05 UTC
+out_data/7_pb0_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-04-19 15:36 UTC

--- a/log/07_habitatPGDL_sb.csv
+++ b/log/07_habitatPGDL_sb.csv
@@ -12,4 +12,4 @@ filepath,sb_id,time_uploaded_to_sb
 ../lake-temperature-out/3_summarize/tmp/pgdl_toha_11_N45.00-45.50_W92.25-93.25.zip,5e774355e4b01d509270e2a1,2021-04-16 14:06 UTC
 ../lake-temperature-out/3_summarize/tmp/pgdl_toha_12_N43.50-45.00_W93.50-96.75.zip,5e774355e4b01d509270e2a1,2021-04-16 14:06 UTC
 ../lake-temperature-out/3_summarize/tmp/pgdl_toha_13_N43.50-45.00_W91.00-93.50.zip,5e774355e4b01d509270e2a1,2021-04-16 14:06 UTC
-out_data/7_pgdl_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-04-16 14:06 UTC
+out_data/7_pgdl_annual_metrics.csv,5e774355e4b01d509270e2a1,2021-04-19 15:37 UTC

--- a/log/07_habitat_xml_sb.csv
+++ b/log/07_habitat_xml_sb.csv
@@ -1,2 +1,2 @@
 filepath,sb_id,time_uploaded_to_sb
-out_xml/07_habitat.xml,5e774355e4b01d509270e2a1,2021-03-30 19:42 UTC
+out_xml/07_habitat.xml,5e774355e4b01d509270e2a1,2021-04-19 15:38 UTC


### PR DESCRIPTION
If there is no data available for the full winter, return NA for ice-on rather than set to the first day of data. These changes were made in https://github.com/USGS-R/lake-temperature-out/pull/55/commits/054acda5dc9c82be161418214c235b07e0192030. This PR actually adds the updated data to SB.

Before these changes, we would return the first day of ice for the winter regardless of whether data was available for the full winter. For the first year in the dataset, 1980, that meant that ice-on was always "1980-01-01" because we didn't have any data in 1979 to say whether ice-on actually occurred at the end of 1979. After the changes, you can now see that all ice-on dates are at the end of a year (compared to when julian day of 1 was used for 1980) and there are a bunch of NAs for the first year in the timeseries (1980) since there was no available data from the previous year (1979).

![image](https://user-images.githubusercontent.com/13220910/115264582-0a4db680-a0fc-11eb-863c-94e95ddaeb11.png)

![image](https://user-images.githubusercontent.com/13220910/115264552-0326a880-a0fc-11eb-90e3-dc06bd3ce9ec.png)
